### PR TITLE
Updating `dts-health-spring-boot-starter` to comply with latest health specs

### DIFF
--- a/packages/dts-health-spring-boot-starter/README.md
+++ b/packages/dts-health-spring-boot-starter/README.md
@@ -65,7 +65,7 @@ public class MyHealthCheck implements HealthCheck {
 	}
 
 	@Override
-	public Map<String, String> getInfo() {
+	public Map<String, String> getMetadata() {
 		return Map.of("url", "https://api.example.com/health");
 	}
 }
@@ -90,16 +90,16 @@ The response will return a JSON object containing the overall health status and 
 
 ```
 {
-  "status": "PASS",
+  "status": "HEALTHY",
   "version": "1.0.0",
   "buildId": "your-build-id",
   "components": [
     {
       "name": "myService",
-      "status": "PASS",
-      "responseTime": 50,
+      "status": "HEALTHY",
+      "responseTimeMs": 50,
       "details": null,
-      "info": {
+      "metadata": {
         "url": "https://api.example.com/health"
       }
     }

--- a/packages/dts-health-spring-boot-starter/src/main/java/ca/gov/dtsstn/health/actuate/DtsHealthEndpoint.java
+++ b/packages/dts-health-spring-boot-starter/src/main/java/ca/gov/dtsstn/health/actuate/DtsHealthEndpoint.java
@@ -52,7 +52,7 @@ public class DtsHealthEndpoint {
 	 * @param securityContext the security context for the current request
 	 * @param includeComponents the components to include in the health check; if null or empty, all components are included
 	 * @param excludeComponents the components to exclude from the health check; any matching component will not be included
-	 * @param timeout the timeout for the health check in milliseconds
+	 * @param timeoutMs the timeout for the health check in milliseconds
 	 * @param level the detail level of the health check result (currently only "detailed" level is accepted)
 	 * @return a {@link WebEndpointResponse} containing the health result and the corresponding HTTP status
 	 */
@@ -60,12 +60,12 @@ public class DtsHealthEndpoint {
 	public WebEndpointResponse<HealthResult> health(SecurityContext securityContext,
 			@Nullable Collection<String> includeComponents,
 			@Nullable Collection<String> excludeComponents,
-			@Nullable Long timeout,
+			@Nullable Long timeoutMs,
 			@Nullable String level) {
 		final var healthCheckOptions = ImmutableHealthCheckOptions.builder()
 				.includeComponents(requireNonNullElse(includeComponents, emptyList()))
 				.excludeComponents(requireNonNullElse(excludeComponents, emptyList()))
-				.timeoutMillis(requireNonNullElse(timeout, dtsHealthProperties.getDefaultTimeoutMillis()))
+				.timeoutMillis(requireNonNullElse(timeoutMs, dtsHealthProperties.getDefaultTimeoutMillis()))
 				.includeDetails(includeDetails(securityContext, "detailed".equals(level)))
 				.version(dtsHealthProperties.getVersion())
 				.buildId(dtsHealthProperties.getBuildId())

--- a/packages/dts-health-spring-boot-starter/src/main/java/ca/gov/dtsstn/health/core/HealthCheck.java
+++ b/packages/dts-health-spring-boot-starter/src/main/java/ca/gov/dtsstn/health/core/HealthCheck.java
@@ -22,14 +22,14 @@ public interface HealthCheck {
 	void execute();
 
 	/**
-	 * Retrieves additional information about the component or service being checked.
+	 * Retrieves metadata about the component or service being checked.
 	 *
 	 * <p>The default implementation returns an empty map. Implementing classes can override this method to provide additional
 	 * context or metadata about the component, such as version numbers, configuration details, or other relevant information.</p>
 	 *
-	 * @return a map of key-value pairs containing additional information about the component; by default, returns an empty map
+	 * @return a map of key-value pairs containing metadata about the component; by default, returns an empty map
 	 */
-	default Map<String, String> getInfo() {
+	default Map<String, String> getMetadata() {
 		return emptyMap();
 	}
 

--- a/packages/dts-health-spring-boot-starter/src/main/java/ca/gov/dtsstn/health/core/HealthResult.java
+++ b/packages/dts-health-spring-boot-starter/src/main/java/ca/gov/dtsstn/health/core/HealthResult.java
@@ -22,12 +22,11 @@ public interface HealthResult {
 	String CONTENT_TYPE = "application/health+json";
 
 	/**
-	 * The possible statuses for a health check result.
+	 * The possible statuses for a system health check result.
 	 */
 	enum Status {
-		PASS(200),
-		FAIL(503),
-		UNKNOWN(500);
+		HEALTHY(200),
+		UNHEALTHY(503);
 
 		private final int httpStatus;
 
@@ -46,6 +45,13 @@ public interface HealthResult {
 	 * @return the {@link Status} of the health check
 	 */
 	Status getStatus();
+
+	/**
+	 * Returns the response time for the overall system health check, in milliseconds.
+	 *
+	 * @return the response time of the overall system health check
+	 */
+	Long getResponseTimeMs();
 
 	/**
 	 * Returns the version of the application or service being checked, if available.
@@ -78,6 +84,15 @@ public interface HealthResult {
 	interface ComponentHealthResult {
 
 		/**
+		 * The possible statuses for a component health check result.
+		 */
+		enum Status {
+			HEALTHY,
+			UNHEALTHY,
+			TIMEDOUT;
+		}
+
+		/**
 		 * Returns the name of the component being checked.
 		 *
 		 * @return the component name
@@ -92,28 +107,37 @@ public interface HealthResult {
 		Status getStatus();
 
 		/**
-		 * Returns the response time for the health check, in milliseconds, if available.
+		 * Returns the response time for the individual component health check, in milliseconds, if available.
 		 *
-		 * @return the response time, or {@code null} if not provided
+		 * @return the response time of the individual component health check, or {@code null} if not provided
 		 */
 		@Nullable
-		Long getResponseTime();
+		Long getResponseTimeMs();
 
 		/**
-		 * Returns additional details about the health check result, if available.
+		 * Returns metadata associated with the component health check, if available.
 		 *
-		 * @return a string with details, or {@code null} if not provided
+		 * @return a map of metadata entries, or {@code null} if no metadata is provided
 		 */
 		@Nullable
-		String getDetails();
+		Map<String, String> getMetadata();
 
 		/**
-		 * Returns additional information related to the health check, if available.
+		 * Returns additional details about any errors encountered during the component health check, if available.
 		 *
-		 * @return a map of additional info, or {@code null} if not provided
+		 * @return a description of the error, or {@code null} if no error occurred or no error is available
 		 */
 		@Nullable
-		Map<String, String> getInfo();
+		String getErrorDetails();
+
+
+		/**
+		 * Returns the stack trace associated with an error during the component health check, if available.
+		 *
+		 * @return the stack trace as a string, or {@code null} if no error occurred or no error is available
+		 */
+		@Nullable
+		String getStackTrace();
 
 	}
 

--- a/packages/dts-health-spring-boot-starter/src/test/java/ca/gov/dtsstn/health/actuate/DtsHealthEndpointIT.java
+++ b/packages/dts-health-spring-boot-starter/src/test/java/ca/gov/dtsstn/health/actuate/DtsHealthEndpointIT.java
@@ -1,24 +1,23 @@
 package ca.gov.dtsstn.health.actuate;
 
-import static ca.gov.dtsstn.health.core.HealthResult.Status.PASS;
-import static org.mockito.Mockito.when;
+import static ca.gov.dtsstn.health.core.HealthResult.Status.UNHEALTHY;
 import static org.springframework.boot.actuate.endpoint.Show.WHEN_AUTHORIZED;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,7 +26,7 @@ import ca.gov.dtsstn.health.core.HealthCheck;
 import ca.gov.dtsstn.health.core.HealthResult;
 
 @SpringBootTest(
-		classes = DtsHealthAutoConfiguration.class,
+		classes = { DtsHealthEndpointIT.TestConfig.class, DtsHealthAutoConfiguration.class },
 		properties = "management.endpoints.web.exposure.include=dtshealth")
 @AutoConfigureMockMvc
 @EnableAutoConfiguration
@@ -35,29 +34,21 @@ class DtsHealthEndpointIT {
 
 	@Autowired MockMvc mockMvc;
 
-	@MockBean DtsHealthProperties dtsHealthProperties;
-
-	@MockBean Collection<HealthCheck> healthChecks;
-
-	@BeforeEach
-	void beforeEach() {
-		when(dtsHealthProperties.getRoles()).thenReturn(Set.of("ADMIN"));
-		when(dtsHealthProperties.getShowDetails()).thenReturn(WHEN_AUTHORIZED);
-		when(dtsHealthProperties.getVersion()).thenReturn("0.0.0");
-		when(dtsHealthProperties.getBuildId()).thenReturn("0.0.0-00000000-0000");
-	}
-
 	@Test
 	void testHealth_detailedRequestForAuthorizedUser() throws Exception {
 		mockMvc.perform(get("/actuator/dtshealth")
 				.param("level", "detailed")
 				.principal(new UsernamePasswordAuthenticationToken("user", "password", List.of(new SimpleGrantedAuthority("ADMIN")))))
 				.andExpect(content().contentType(HealthResult.CONTENT_TYPE))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.status").value(PASS.toString()))
+				.andExpect(status().isServiceUnavailable())
+				.andExpect(jsonPath("$.status").value(UNHEALTHY.toString()))
+				.andExpect(jsonPath("$.responseTimeMs").isNumber())
 				.andExpect(jsonPath("$.version").value("0.0.0"))
 				.andExpect(jsonPath("$.buildId").value("0.0.0-00000000-0000"))
-				.andExpect(jsonPath("$.components").exists());
+				.andExpect(jsonPath("$.components[0].name").value("API"))
+				.andExpect(jsonPath("$.components[0].metadata").isNotEmpty())
+				.andExpect(jsonPath("$.components[0].errorDetails").isNotEmpty())
+				.andExpect(jsonPath("$.components[0].stackTrace").isNotEmpty());
 	}
 
 	@Test
@@ -65,11 +56,51 @@ class DtsHealthEndpointIT {
 		mockMvc.perform(get("/actuator/dtshealth")
 				.param("level", "detailed"))
 				.andExpect(content().contentType(HealthResult.CONTENT_TYPE))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.status").value(PASS.toString()))
-				.andExpect(jsonPath("$.version").doesNotExist())
-				.andExpect(jsonPath("$.buildId").doesNotExist())
-				.andExpect(jsonPath("$.components").doesNotExist());
+				.andExpect(status().isServiceUnavailable())
+				.andExpect(jsonPath("$.status").value(UNHEALTHY.toString()))
+				.andExpect(jsonPath("$.responseTimeMs").isNumber())
+				.andExpect(jsonPath("$.version").value("0.0.0"))
+				.andExpect(jsonPath("$.buildId").value("0.0.0-00000000-0000"))
+				.andExpect(jsonPath("$.components[0].name").value("API"))
+				.andExpect(jsonPath("$.components[0].metadata").doesNotExist())
+				.andExpect(jsonPath("$.components[0].errorDetails").doesNotExist())
+				.andExpect(jsonPath("$.components[0].stackTrace").doesNotExist());
+	}
+
+	@Configuration
+	static class TestConfig {
+
+		@Bean DtsHealthProperties dtsHealthProperties() {
+			final var dtsHealthProperties = new DtsHealthProperties();
+			dtsHealthProperties.setRoles(Set.of("ADMIN"));
+			dtsHealthProperties.setShowDetails(WHEN_AUTHORIZED);
+			dtsHealthProperties.setVersion("0.0.0");
+			dtsHealthProperties.setBuildId("0.0.0-00000000-0000");
+			dtsHealthProperties.setDefaultTimeoutMillis(10000L);
+			return dtsHealthProperties;
+		}
+
+		@Bean HealthCheck testHealthCheck() {
+			return new HealthCheck() {
+
+				@Override
+				public String getName() {
+					return "API";
+				}
+
+				@Override
+				public void execute() {
+					throw new RuntimeException("API execution failed");
+				}
+
+				@Override
+				public Map<String, String> getMetadata() {
+					return Map.of("url", "http://api.example.com");
+				}
+
+			};
+		}
+
 	}
 
 }

--- a/packages/dts-health-spring-boot-starter/src/test/java/ca/gov/dtsstn/health/actuate/DtsHealthEndpointTest.java
+++ b/packages/dts-health-spring-boot-starter/src/test/java/ca/gov/dtsstn/health/actuate/DtsHealthEndpointTest.java
@@ -1,6 +1,6 @@
 package ca.gov.dtsstn.health.actuate;
 
-import static ca.gov.dtsstn.health.core.HealthResult.Status.PASS;
+import static ca.gov.dtsstn.health.core.HealthResult.Status.HEALTHY;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -60,9 +60,10 @@ class DtsHealthEndpointTest {
 				.includeDetails(true)
 				.build();
 
-		final var status = PASS;
+		final var status = HEALTHY;
 		final var healthResult = ImmutableHealthResult.builder()
 				.status(status)
+				.responseTimeMs(30L)
 				.build();
 
 		when(healthCheckManager.executeChecks(healthChecks, healthCheckOptions)).thenReturn(healthResult);
@@ -90,9 +91,10 @@ class DtsHealthEndpointTest {
 				.includeDetails(false)
 				.build();
 
-		final var status = PASS;
+		final var status = HEALTHY;
 		final var healthResult = ImmutableHealthResult.builder()
 				.status(status)
+				.responseTimeMs(30L)
 				.build();
 
 		when(healthCheckManager.executeChecks(healthChecks, healthCheckOptions)).thenReturn(healthResult);

--- a/packages/dts-health-spring-boot-starter/src/test/java/ca/gov/dtsstn/health/core/HealthCheckManagerTest.java
+++ b/packages/dts-health-spring-boot-starter/src/test/java/ca/gov/dtsstn/health/core/HealthCheckManagerTest.java
@@ -1,8 +1,5 @@
 package ca.gov.dtsstn.health.core;
 
-import static ca.gov.dtsstn.health.core.HealthResult.Status.FAIL;
-import static ca.gov.dtsstn.health.core.HealthResult.Status.PASS;
-import static ca.gov.dtsstn.health.core.HealthResult.Status.UNKNOWN;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doAnswer;
@@ -19,12 +16,16 @@ import org.mockito.Mock;
 import org.mockito.internal.stubbing.answers.AnswersWithDelay;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import ca.gov.dtsstn.health.core.HealthResult.ComponentHealthResult;
+import ca.gov.dtsstn.health.core.HealthResult.Status;
+
 @ExtendWith(MockitoExtension.class)
 class HealthCheckManagerTest {
 
 	HealthCheckManager healthCheckManager;
 
-	@Mock HealthCheck healthCheck;
+	@Mock
+	HealthCheck healthCheck;
 
 	@BeforeEach
 	void beforeEach() {
@@ -32,9 +33,9 @@ class HealthCheckManagerTest {
 	}
 
 	@Test
-	void testExecuteChecks_DetailsIncluded() {
+	void testExecuteChecks() {
 		when(healthCheck.getName()).thenReturn("API");
-		when(healthCheck.getInfo()).thenReturn(Map.of("url", "http://api.example.com"));
+		when(healthCheck.getMetadata()).thenReturn(Map.of("url", "http://api.example.com"));
 
 		final var healthChecks = List.of(healthCheck);
 		final var healthCheckOptions = ImmutableHealthCheckOptions.builder()
@@ -45,26 +46,10 @@ class HealthCheckManagerTest {
 				.build();
 		final var result = healthCheckManager.executeChecks(healthChecks, healthCheckOptions);
 
-		assertThat(result.getStatus()).isEqualTo(PASS);
+		assertThat(result.getStatus()).isEqualTo(Status.HEALTHY);
 		assertThat(result.getBuildId()).isEqualTo("0.0.0-00000000-0000");
 		assertThat(result.getVersion()).isEqualTo("0.0.0");
 		assertThat(result.getComponents()).isNotEmpty();
-	}
-
-	@Test
-	void testExecuteChecks_DetailsExcluded() {
-		when(healthCheck.getName()).thenReturn("API");
-		when(healthCheck.getInfo()).thenReturn(Map.of("url", "http://api.example.com"));
-
-		final var healthChecks = List.of(healthCheck);
-		final var healthCheckOptions = ImmutableHealthCheckOptions.builder()
-				.includeDetails(false)
-				.timeoutMillis(3000)
-				.build();
-		final var result = healthCheckManager.executeChecks(healthChecks, healthCheckOptions);
-
-		assertThat(result.getStatus()).isEqualTo(PASS);
-		assertThat(result.getComponents()).isNull();
 	}
 
 	@Test
@@ -125,97 +110,97 @@ class HealthCheckManagerTest {
 	@Test
 	void testExecuteCheckWithTimeout_SuccessfulExecution() {
 		when(healthCheck.getName()).thenReturn("API");
-		when(healthCheck.getInfo()).thenReturn(Map.of("url", "http://api.example.com"));
+		when(healthCheck.getMetadata()).thenReturn(Map.of("url", "http://api.example.com"));
 
 		final var timeout = 10;
-		final var result = healthCheckManager.executeCheckWithTimeout(healthCheck, timeout);
+		final var result = healthCheckManager.executeCheckWithTimeout(healthCheck, timeout, true);
 
-		assertThat(result.getStatus()).isEqualTo(PASS);
+		assertThat(result.getStatus()).isEqualTo(ComponentHealthResult.Status.HEALTHY);
 		assertThat(result.getName()).isEqualTo("API");
-		assertThat(result.getInfo()).isEqualTo(Map.of("url", "http://api.example.com"));
-		assertThat(result.getDetails()).isNull();
+		assertThat(result.getMetadata()).isEqualTo(Map.of("url", "http://api.example.com"));
+		assertThat(result.getErrorDetails()).isNull();
 	}
 
 	@Test
 	void testExecuteCheckWithTimeout_ExecutionTimeExceedsTimeout() {
 		when(healthCheck.getName()).thenReturn("API");
-		when(healthCheck.getInfo()).thenReturn(Map.of("url", "http://api.example.com"));
+		when(healthCheck.getMetadata()).thenReturn(Map.of("url", "http://api.example.com"));
 		doAnswer(new AnswersWithDelay(20, null)).when(healthCheck).execute();
 
 		final var timeout = 10;
-		final var result = healthCheckManager.executeCheckWithTimeout(healthCheck, timeout);
+		final var result = healthCheckManager.executeCheckWithTimeout(healthCheck, timeout, true);
 
-		assertThat(result.getStatus()).isEqualTo(UNKNOWN);
+		assertThat(result.getStatus()).isEqualTo(ComponentHealthResult.Status.TIMEDOUT);
 		assertThat(result.getName()).isEqualTo("API");
-		assertThat(result.getInfo()).isEqualTo(Map.of("url", "http://api.example.com"));
-		assertThat(result.getDetails()).contains("TimeoutException");
+		assertThat(result.getMetadata()).isEqualTo(Map.of("url", "http://api.example.com"));
+		assertThat(result.getErrorDetails()).contains("TimeoutException");
 	}
 
 	@Test
-	void testBuildUnknownResult() {
+	void testBuildTimedOutResult() {
 		final var healthCheckName = "API";
 		final var healthCheckInfo = Map.of("url", "http://api.example.com");
 		final var timeoutMillis = 3000;
 		final var exception = new RuntimeException("API execution failed");
-		final var result = healthCheckManager.buildUnknownResult(healthCheckName, healthCheckInfo, timeoutMillis, exception);
+		final var result = healthCheckManager.buildTimedOutResult(healthCheckName, healthCheckInfo, timeoutMillis, true, exception);
 
-		assertThat(result.getStatus()).isEqualTo(UNKNOWN);
+		assertThat(result.getStatus()).isEqualTo(ComponentHealthResult.Status.TIMEDOUT);
 		assertThat(result.getName()).isEqualTo("API");
-		assertThat(result.getInfo()).isEqualTo(Map.of("url", "http://api.example.com"));
-		assertThat(result.getDetails()).contains("API execution failed");
+		assertThat(result.getMetadata()).isEqualTo(Map.of("url", "http://api.example.com"));
+		assertThat(result.getErrorDetails()).contains("API execution failed");
 	}
 
 	@Test
 	void testExecuteCheck_HealthCheckSuccessful() {
 		when(healthCheck.getName()).thenReturn("API");
-		when(healthCheck.getInfo()).thenReturn(Map.of("url", "http://api.example.com"));
+		when(healthCheck.getMetadata()).thenReturn(Map.of("url", "http://api.example.com"));
 
-		final var result = healthCheckManager.executeCheck(healthCheck);
+		final var result = healthCheckManager.executeCheck(healthCheck, true);
 
-		assertThat(result.getStatus()).isEqualTo(PASS);
+		assertThat(result.getStatus()).isEqualTo(ComponentHealthResult.Status.HEALTHY);
 		assertThat(result.getName()).isEqualTo("API");
-		assertThat(result.getInfo()).isEqualTo(Map.of("url", "http://api.example.com"));
-		assertThat(result.getResponseTime()).isNotNegative();
-		assertThat(result.getDetails()).isNull();
+		assertThat(result.getMetadata()).isEqualTo(Map.of("url", "http://api.example.com"));
+		assertThat(result.getResponseTimeMs()).isNotNegative();
+		assertThat(result.getErrorDetails()).isNull();
 	}
 
 	@Test
 	void testExecuteCheck_HealthCheckThrows() {
 		when(healthCheck.getName()).thenReturn("API");
-		when(healthCheck.getInfo()).thenReturn(Map.of("url", "http://api.example.com"));
+		when(healthCheck.getMetadata()).thenReturn(Map.of("url", "http://api.example.com"));
 		doThrow(new RuntimeException("API execution failed")).when(healthCheck).execute();
 
-		final var result = healthCheckManager.executeCheck(healthCheck);
+		final var result = healthCheckManager.executeCheck(healthCheck, true);
 
-		assertThat(result.getStatus()).isEqualTo(FAIL);
+		assertThat(result.getStatus()).isEqualTo(ComponentHealthResult.Status.UNHEALTHY);
 		assertThat(result.getName()).isEqualTo("API");
-		assertThat(result.getInfo()).isEqualTo(Map.of("url", "http://api.example.com"));
-		assertThat(result.getResponseTime()).isNotNegative();
-		assertThat(result.getDetails()).contains("API execution failed");
+		assertThat(result.getMetadata()).isEqualTo(Map.of("url", "http://api.example.com"));
+		assertThat(result.getResponseTimeMs()).isNotNegative();
+		assertThat(result.getErrorDetails()).contains("API execution failed");
 	}
 
 	@Test
-	void testAggregateStatus_AllStatusesPass() {
-		final var allStatuses = List.of(PASS, PASS, PASS);
+	void testAggregateStatus_AllStatusesHealthy() {
+		final var allStatuses = List.of(ComponentHealthResult.Status.HEALTHY, ComponentHealthResult.Status.HEALTHY, ComponentHealthResult.Status.HEALTHY);
 		final var status = healthCheckManager.aggregateStatus(allStatuses);
 
-		assertThat(status).isEqualTo(PASS);
+		assertThat(status).isEqualTo(Status.HEALTHY);
 	}
 
 	@Test
-	void testAggregateStatus_OneStatusFail() {
-		final var allStatuses = List.of(PASS, UNKNOWN, FAIL);
+	void testAggregateStatus_OneStatusUnhealthy() {
+		final var allStatuses = List.of(ComponentHealthResult.Status.HEALTHY, ComponentHealthResult.Status.HEALTHY, ComponentHealthResult.Status.UNHEALTHY);
 		final var status = healthCheckManager.aggregateStatus(allStatuses);
 
-		assertThat(status).isEqualTo(FAIL);
+		assertThat(status).isEqualTo(Status.UNHEALTHY);
 	}
 
 	@Test
-	void testAggregateStatus_AllStatusesPassOneStatusUnknown() {
-		final var allStatuses = List.of(PASS, UNKNOWN, PASS);
+	void testAggregateStatus_AllStatusesHealthyOneStatusTimedout() {
+		final var allStatuses = List.of(ComponentHealthResult.Status.HEALTHY, ComponentHealthResult.Status.TIMEDOUT, ComponentHealthResult.Status.HEALTHY);
 		final var status = healthCheckManager.aggregateStatus(allStatuses);
 
-		assertThat(status).isEqualTo(UNKNOWN);
+		assertThat(status).isEqualTo(Status.UNHEALTHY);
 	}
 
 }


### PR DESCRIPTION
This PR updates field and status names to adhere to the latest health specification standards and enhances the health check functionality to provide more detailed information when requested.

**Field name changes:**
- `info` → `metadata`
- `responseTime` → `responseTimeMs`
- `timeout` → `timeoutMs`
- `details` → `errorDetails` and `stackTrace` 

**Status name changes:**
- `PASS` → `HEALTHY`
- `FAIL` → `UNHEALTHY`
- `UNKNOWN` → `TIMEDOUT`

**Functionality changes:**
- If `showDetails` is `true`, the health check will return `metadata`, `errorDetails` and `stackTrace` where applicable. Before, the health check only returned the aggregated system health status.