### PR TITLE
Renaming `groupId` and package names to match registered namespace and adding requirements for minimal POM information

### DIFF
--- a/packages/dts-health-spring-boot-starter/README.md
+++ b/packages/dts-health-spring-boot-starter/README.md
@@ -14,9 +14,9 @@ Add the following dependency to your `pom.xml`:
 
 ```
 <dependency>
-	<groupId>ca.gov.dts-stn</groupId>
+	<groupId>io.github.dts-stn</groupId>
 	<artifactId>dts-health-spring-boot-starter</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.0-RC1</version>
 </dependency>
 ```
 
@@ -50,7 +50,7 @@ dts-health:
 To implement a health check, create a class that implements the `HealthCheck` interface:
 
 ```
-import ca.gov.dtsstn.health.core.HealthCheck;
+import io.github.dtsstn.health.core.HealthCheck;
 
 public class MyHealthCheck implements HealthCheck {
 	

--- a/packages/dts-health-spring-boot-starter/pom.xml
+++ b/packages/dts-health-spring-boot-starter/pom.xml
@@ -5,22 +5,55 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.4</version>
+		<version>3.3.5</version>
 	</parent>
 
-	<groupId>ca.gov.dts-stn</groupId>
+	<groupId>io.github.dts-stn</groupId>
 	<artifactId>dts-health-spring-boot-starter</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.0-RC1</version>
 	<packaging>jar</packaging>
 
-	<name>dts-health-spring-boot-starter</name>
+	<name>${project.groupId}:${project.artifactId}</name>
 	<description>A spring boot starter for customizing health checks to conform to DTS health check standards</description>
+	<url>https://github.com/DTS-STN/dts-wide/tree/main/packages/dts-health-spring-boot-starter</url>
+
+	<developers>
+		<developer>
+			<name>Nicholas Ly</name>
+			<email>nicholas.ly@hrsdc-rhdcc.gc.ca</email>
+			<organization>Government of Canada</organization>
+			<organizationUrl>https://canada.ca/</organizationUrl>
+		</developer>
+
+		<developer>
+			<name>Greg Baker</name>
+			<email>gregory.j.baker@hrsdc-rhdcc.gc.ca</email>
+			<organization>Government of Canada</organization>
+			<organizationUrl>https://canada.ca/</organizationUrl>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:git://github.com/DTS-STN/dts-wide.git</connection>
+		<developerConnection>scm:git:ssh://github.com:DTS-STN/dts-wide.git</developerConnection>
+		<url>https://github.com/DTS-STN/dts-wide/tree/main/packages/dts-health-spring-boot-starter</url>
+	</scm>
+
+	<licenses>
+		<license>
+			<name>MIT License</name>
+			<url>http://www.opensource.org/licenses/mit-license.php</url>
+		</license>
+	</licenses>
 
 	<properties>
 		<java.version>21</java.version>
-		
+
 		<guava.version>33.3.1-jre</guava.version>
 		<immutables.version>2.10.1</immutables.version>
+
+		<central-publishing-maven-plugin.version>0.6.0</central-publishing-maven-plugin.version>
+		<maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -91,6 +124,56 @@
 							<version>${immutables.version}</version>
 						</path>
 					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<additionalOptions>-Xdoclint:none</additionalOptions>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>${maven-gpg-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.sonatype.central</groupId>
+				<artifactId>central-publishing-maven-plugin</artifactId>
+				<version>${central-publishing-maven-plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<publishingServerId>central</publishingServerId>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/actuate/DtsHealthAutoConfiguration.java
+++ b/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/actuate/DtsHealthAutoConfiguration.java
@@ -1,4 +1,4 @@
-package ca.gov.dtsstn.health.actuate;
+package io.github.dtsstn.health.actuate;
 
 import java.util.Collection;
 
@@ -9,8 +9,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
-import ca.gov.dtsstn.health.core.HealthCheck;
-import ca.gov.dtsstn.health.core.HealthCheckManager;
+import io.github.dtsstn.health.core.HealthCheck;
+import io.github.dtsstn.health.core.HealthCheckManager;
 
 /**
  * Auto-configuration class for DTS Health indicators.

--- a/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/actuate/DtsHealthEndpoint.java
+++ b/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/actuate/DtsHealthEndpoint.java
@@ -1,4 +1,4 @@
-package ca.gov.dtsstn.health.actuate;
+package io.github.dtsstn.health.actuate;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNullElse;
@@ -12,10 +12,10 @@ import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
-import ca.gov.dtsstn.health.core.HealthCheck;
-import ca.gov.dtsstn.health.core.HealthCheckManager;
-import ca.gov.dtsstn.health.core.HealthResult;
-import ca.gov.dtsstn.health.core.ImmutableHealthCheckOptions;
+import io.github.dtsstn.health.core.HealthCheck;
+import io.github.dtsstn.health.core.HealthCheckManager;
+import io.github.dtsstn.health.core.HealthResult;
+import io.github.dtsstn.health.core.ImmutableHealthCheckOptions;
 
 /**
  * Custom Spring Actuator endpoint for performing health checks on DTS services.

--- a/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/actuate/DtsHealthProperties.java
+++ b/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/actuate/DtsHealthProperties.java
@@ -1,4 +1,4 @@
-package ca.gov.dtsstn.health.actuate;
+package io.github.dtsstn.health.actuate;
 
 import static org.springframework.boot.actuate.endpoint.Show.WHEN_AUTHORIZED;
 

--- a/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/core/HealthCheck.java
+++ b/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/core/HealthCheck.java
@@ -1,4 +1,4 @@
-package ca.gov.dtsstn.health.core;
+package io.github.dtsstn.health.core;
 
 import static java.util.Collections.emptyMap;
 

--- a/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/core/HealthCheckManager.java
+++ b/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/core/HealthCheckManager.java
@@ -1,4 +1,4 @@
-package ca.gov.dtsstn.health.core;
+package io.github.dtsstn.health.core;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -13,8 +13,8 @@ import java.util.function.Predicate;
 
 import com.google.common.base.Stopwatch;
 
-import ca.gov.dtsstn.health.core.HealthResult.ComponentHealthResult;
-import ca.gov.dtsstn.health.core.HealthResult.Status;
+import io.github.dtsstn.health.core.HealthResult.ComponentHealthResult;
+import io.github.dtsstn.health.core.HealthResult.Status;
 
 /**
  * Manages the execution and aggregation of health checks for components.

--- a/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/core/HealthCheckOptions.java
+++ b/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/core/HealthCheckOptions.java
@@ -1,4 +1,4 @@
-package ca.gov.dtsstn.health.core;
+package io.github.dtsstn.health.core;
 
 import java.util.Set;
 

--- a/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/core/HealthResult.java
+++ b/packages/dts-health-spring-boot-starter/src/main/java/io/github/dtsstn/health/core/HealthResult.java
@@ -1,4 +1,4 @@
-package ca.gov.dtsstn.health.core;
+package io.github.dtsstn.health.core;
 
 import java.util.Map;
 import java.util.Set;

--- a/packages/dts-health-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/packages/dts-health-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,1 @@
-ca.gov.dtsstn.health.actuate.DtsHealthAutoConfiguration
+io.github.dtsstn.health.actuate.DtsHealthAutoConfiguration

--- a/packages/dts-health-spring-boot-starter/src/test/java/io/github/dtsstn/health/actuate/DtsHealthAutoConfigurationIT.java
+++ b/packages/dts-health-spring-boot-starter/src/test/java/io/github/dtsstn/health/actuate/DtsHealthAutoConfigurationIT.java
@@ -1,4 +1,4 @@
-package ca.gov.dtsstn.health.actuate;
+package io.github.dtsstn.health.actuate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import ca.gov.dtsstn.health.core.HealthCheckManager;
+import io.github.dtsstn.health.core.HealthCheckManager;
 
 class DtsHealthAutoConfigurationIT {
 

--- a/packages/dts-health-spring-boot-starter/src/test/java/io/github/dtsstn/health/actuate/DtsHealthEndpointIT.java
+++ b/packages/dts-health-spring-boot-starter/src/test/java/io/github/dtsstn/health/actuate/DtsHealthEndpointIT.java
@@ -1,6 +1,6 @@
-package ca.gov.dtsstn.health.actuate;
+package io.github.dtsstn.health.actuate;
 
-import static ca.gov.dtsstn.health.core.HealthResult.Status.UNHEALTHY;
+import static io.github.dtsstn.health.core.HealthResult.Status.UNHEALTHY;
 import static org.springframework.boot.actuate.endpoint.Show.WHEN_AUTHORIZED;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -22,8 +22,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 
-import ca.gov.dtsstn.health.core.HealthCheck;
-import ca.gov.dtsstn.health.core.HealthResult;
+import io.github.dtsstn.health.core.HealthCheck;
+import io.github.dtsstn.health.core.HealthResult;
 
 @SpringBootTest(
 		classes = { DtsHealthEndpointIT.TestConfig.class, DtsHealthAutoConfiguration.class },

--- a/packages/dts-health-spring-boot-starter/src/test/java/io/github/dtsstn/health/actuate/DtsHealthEndpointTest.java
+++ b/packages/dts-health-spring-boot-starter/src/test/java/io/github/dtsstn/health/actuate/DtsHealthEndpointTest.java
@@ -1,6 +1,6 @@
-package ca.gov.dtsstn.health.actuate;
+package io.github.dtsstn.health.actuate;
 
-import static ca.gov.dtsstn.health.core.HealthResult.Status.HEALTHY;
+import static io.github.dtsstn.health.core.HealthResult.Status.HEALTHY;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -17,10 +17,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.endpoint.SecurityContext;
 import org.springframework.boot.actuate.endpoint.Show;
 
-import ca.gov.dtsstn.health.core.HealthCheck;
-import ca.gov.dtsstn.health.core.HealthCheckManager;
-import ca.gov.dtsstn.health.core.ImmutableHealthCheckOptions;
-import ca.gov.dtsstn.health.core.ImmutableHealthResult;
+import io.github.dtsstn.health.core.HealthCheck;
+import io.github.dtsstn.health.core.HealthCheckManager;
+import io.github.dtsstn.health.core.ImmutableHealthCheckOptions;
+import io.github.dtsstn.health.core.ImmutableHealthResult;
 
 @ExtendWith(MockitoExtension.class)
 class DtsHealthEndpointTest {

--- a/packages/dts-health-spring-boot-starter/src/test/java/io/github/dtsstn/health/core/HealthCheckManagerTest.java
+++ b/packages/dts-health-spring-boot-starter/src/test/java/io/github/dtsstn/health/core/HealthCheckManagerTest.java
@@ -1,4 +1,4 @@
-package ca.gov.dtsstn.health.core;
+package io.github.dtsstn.health.core;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,8 +16,8 @@ import org.mockito.Mock;
 import org.mockito.internal.stubbing.answers.AnswersWithDelay;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import ca.gov.dtsstn.health.core.HealthResult.ComponentHealthResult;
-import ca.gov.dtsstn.health.core.HealthResult.Status;
+import io.github.dtsstn.health.core.HealthResult.ComponentHealthResult;
+import io.github.dtsstn.health.core.HealthResult.Status;
 
 @ExtendWith(MockitoExtension.class)
 class HealthCheckManagerTest {


### PR DESCRIPTION
Manually changing the version until release process is automated.

References:
- https://central.sonatype.org/register/namespace/
- https://central.sonatype.org/publish/requirements/
- https://central.sonatype.org/publish/publish-maven/
- https://central.sonatype.org/publish/publish-portal-maven/
- https://central.sonatype.com/artifact/io.github.dts-stn/dts-health-spring-boot-starter
